### PR TITLE
Adding support for not waiting for parsing to finish

### DIFF
--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -45,7 +45,7 @@ function getState(queryVars) {
     connectionId: queryVars["connection_id"],
     accessToken: queryVars["access_token"],
     demo: !!queryVars["demo"] && queryVars["demo"] === "true",
-    ignoreParsing: queryVars["ignore_parsing"] === "true" ? true : false
+    ignoreParsing: queryVars["ignore_parsing"] === "true"
   };
 }
 

--- a/static/js/helpers.js
+++ b/static/js/helpers.js
@@ -44,7 +44,8 @@ function getState(queryVars) {
     userId: queryVars["user_id"],
     connectionId: queryVars["connection_id"],
     accessToken: queryVars["access_token"],
-    demo: !!queryVars["demo"] && queryVars["demo"] === "true"
+    demo: !!queryVars["demo"] && queryVars["demo"] === "true",
+    ignoreParsing: queryVars["ignore_parsing"] === "true" ? true : false
   };
 }
 

--- a/static/js/pages/pdfUpload.js
+++ b/static/js/pages/pdfUpload.js
@@ -93,6 +93,11 @@ window.pages["pdfUpload"] = function (container, institution) {
     });
 
     pdfDropzone.on("queuecomplete", function () {
+        if (window.globalState.ignoreParsing) {
+            transitionToPage("pdfResult", "success", institution, []);
+            return;
+        }
+
         var promises = [];
         window.jobIds.forEach(function(jobId){
             promises.push(new Promise(function(resolve, reject){


### PR DESCRIPTION
If we want basiq-blink not to wait for parsing to finish we should pass 'ignore_parsing=true' in url as query parameter.